### PR TITLE
bacpop-143 update for GPS_v6

### DIFF
--- a/config/beebop.yml
+++ b/config/beebop.yml
@@ -13,7 +13,7 @@ server:
   image:
     repo: mrcide
     name: beebop-server
-    tag: bacpop-145
+    tag: main
   port: 4000
   redis_url: "redis://beebop-redis:6379"
 api:

--- a/config/beebop.yml
+++ b/config/beebop.yml
@@ -13,13 +13,13 @@ server:
   image:
     repo: mrcide
     name: beebop-server
-    tag: main
+    tag: bacpop-25
   port: 4000
 api:
   image:
     repo: mrcide
     name: beebop-py
-    tag: main
+    tag: bacpop-25
   db_location: ./storage/GPS_v6_references
   use_small_db: true
   storage_location: ./storage

--- a/config/beebop.yml
+++ b/config/beebop.yml
@@ -19,7 +19,7 @@ api:
   image:
     repo: mrcide
     name: beebop-py
-    tag: bacpop-25
+    tag: main
   db_location: ./storage/GPS_v6_references
   use_small_db: true
   storage_location: ./storage

--- a/config/beebop.yml
+++ b/config/beebop.yml
@@ -13,8 +13,9 @@ server:
   image:
     repo: mrcide
     name: beebop-server
-    tag: bacpop-25
+    tag: bacpop-145
   port: 4000
+  redis_url: "redis://beebop-redis:6379"
 api:
   image:
     repo: mrcide

--- a/config/beebop.yml
+++ b/config/beebop.yml
@@ -20,7 +20,7 @@ api:
     repo: mrcide
     name: beebop-py
     tag: main
-  db_location: ./storage/GPS_v4_references
+  db_location: ./storage/GPS_v6_references
   use_small_db: true
   storage_location: ./storage
 redis:

--- a/config/dev.yml
+++ b/config/dev.yml
@@ -3,12 +3,12 @@ server:
   server_url: https://localhost/api
   auth:
     google:
-      client_id: VAULT:secret/beebop/auth/google:clientid
-      secret: VAULT:secret/beebop/auth/google:secret
+      client_id: VAULT:secret/beebop/auth/devdocker/google:clientid
+      secret: VAULT:secret/beebop/auth/devdocker/google:secret
     session_secret: VAULT:secret/beebop/express-session:secret
     github:
-      client_id: VAULT:secret/beebop/auth/github:clientid
-      secret: VAULT:secret/beebop/auth/github:secret
+      client_id: VAULT:secret/beebop/auth/devdocker/github:clientid
+      secret: VAULT:secret/beebop/auth/devdocker/github:secret
 vault:
   addr: https://vault.dide.ic.ac.uk:8200
   auth:

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -19,7 +19,7 @@ vault:
   auth:
     method: github
 api:
-  db_location: ./storage/GPS_v4
+  db_location: ./storage/GPS_v6
   use_small_db: false
 worker:
   count: 5

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -1,8 +1,8 @@
 proxy:
   host: beebop.dide.ic.ac.uk
   ssl:
-    certificate: VAULT:secret/beebop/ssl:cert
-    key: VAULT:secret/beebop/ssl:key
+    certificate: VAULT:secret/beebop/ssl/production:cert
+    key: VAULT:secret/beebop/ssl/production:key
 server:
   client_url: https://beebop.dide.ic.ac.uk
   server_url: https://beebop.dide.ic.ac.uk/api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-constellation==0.0.12
+constellation==1.0.0
 docopt
 pytest
 timeago

--- a/src/beebop_deploy.py
+++ b/src/beebop_deploy.py
@@ -76,6 +76,7 @@ class BeebopConfig:
         self.server_port = config.config_integer(dat, ["server", "port"])
         self.client_url = config.config_string(dat, ["server", "client_url"])
         self.server_url = config.config_string(dat, ["server", "server_url"])
+        self.redis_url = config.config_string(dat, ["server", "redis_url"])
         self.google_client_id = config.config_string(
             dat, ["server", "auth", "google", "client_id"])
         self.google_client_secret = config.config_string(
@@ -199,6 +200,7 @@ def server_configure(api):
             "api_url": "http://{}:5000".format(api.name),
             "client_url": cfg.client_url,
             "server_url": cfg.server_url,
+            "redis_url": cfg.redis_url,
             "GOOGLE_CLIENT_ID": cfg.google_client_id,
             "GOOGLE_CLIENT_SECRET": cfg.google_client_secret,
             "GITHUB_CLIENT_ID": cfg.github_client_id,

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -26,19 +26,19 @@ def test_start_beebop():
 
     assert docker_util.network_exists("beebop_nw")
     assert docker_util.volume_exists("beebop_storage")
-    assert docker_util.container_exists("beebop_api")
-    assert docker_util.container_exists("beebop_redis")
-    assert docker_util.container_exists("beebop_server")
-    assert docker_util.container_exists("beebop_proxy")
-    assert len(docker_util.containers_matching("beebop_worker_", False)) == 2
+    assert docker_util.container_exists("beebop-api")
+    assert docker_util.container_exists("beebop-redis")
+    assert docker_util.container_exists("beebop-server")
+    assert docker_util.container_exists("beebop-proxy")
+    assert len(docker_util.containers_matching("beebop-worker-", False)) == 2
 
     obj.destroy()
 
     assert not docker_util.network_exists("beebop_nw")
     assert not docker_util.volume_exists("beebop_storage")
-    assert not docker_util.container_exists("beebop_api")
-    assert not docker_util.container_exists("beebop_redis")
-    assert not docker_util.container_exists("beebop_server")
-    assert not docker_util.container_exists("beebop_worker")
-    assert not docker_util.container_exists("beebop_proxy")
-    assert len(docker_util.containers_matching("beebop_worker_", False)) == 0
+    assert not docker_util.container_exists("beebop-api")
+    assert not docker_util.container_exists("beebop-redis")
+    assert not docker_util.container_exists("beebop-server")
+    assert not docker_util.container_exists("beebop-worker")
+    assert not docker_util.container_exists("beebop-proxy")
+    assert len(docker_util.containers_matching("beebop-worker-", False)) == 0


### PR DESCRIPTION
Updates config for GPS_v6 database

Also fixes dev configuration by getting correct OAuth app details from vault, and setting redis url. 
You should be able to run this configuration locally with: `./beebop start --pull dev` 
The app should be available at https://localhost

There's a separate ticket to add a working staging configuration: https://mrc-ide.myjetbrains.com/youtrack/issue/bacpop-150