### PR TITLE
Increase node server memory

### DIFF
--- a/config/dev.yml
+++ b/config/dev.yml
@@ -1,4 +1,5 @@
 server:
+  node_options: "--max-old-space-size=8192"
   client_url: https://localhost
   server_url: https://localhost/api
   auth:

--- a/config/fake.yml
+++ b/config/fake.yml
@@ -1,4 +1,5 @@
 server:
+  node_options: "--max-old-space-size=4096"
   client_url: https://localhost
   server_url: https://localhost/api
   auth:

--- a/config/prod.yml
+++ b/config/prod.yml
@@ -1,6 +1,7 @@
 proxy:
   host: beebop.dide.ic.ac.uk
 server:
+  node_options: "--max-old-space-size=8192"
   client_url: https://beebop.dide.ic.ac.uk
   server_url: https://beebop.dide.ic.ac.uk/api
   auth:

--- a/config/staging.yml
+++ b/config/staging.yml
@@ -1,6 +1,7 @@
 proxy:
   host: beebop-dev.dide.ic.ac.uk
 server:
+  node_options: "--max-old-space-size=8192"
   client_url: https://beebop-dev.dide.ic.ac.uk
   server_url: https://beebop-dev.dide.ic.ac.uk/api
   auth:

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -17,7 +17,7 @@ wait_for()
     return $result
 }
 
-# The variable expansion below is 20s by default, or the argument provided
+# The variable expansion below is 30s by default, or the argument provided
 # to this script
 TIMEOUT="${1:-30}"
 wait_for

--- a/scripts/wait_for_redis
+++ b/scripts/wait_for_redis
@@ -19,7 +19,7 @@ wait_for()
 
 # The variable expansion below is 20s by default, or the argument provided
 # to this script
-TIMEOUT="${1:-20}"
+TIMEOUT="${1:-30}"
 wait_for
 RESULT=$?
 if [[ $RESULT -ne 0 ]]; then

--- a/src/beebop_deploy.py
+++ b/src/beebop_deploy.py
@@ -74,7 +74,8 @@ class BeebopConfig:
         self.client_url = config.config_string(dat, ["server", "client_url"])
         self.server_url = config.config_string(dat, ["server", "server_url"])
         self.redis_url = config.config_string(dat, ["server", "redis_url"])
-        self.server_node_options = config.config_string(dat, ["server", "node_options"])
+        self.server_node_options = config.config_string(
+            dat, ["server", "node_options"], is_optional=True, default="")
         self.google_client_id = config.config_string(
             dat, ["server", "auth", "google", "client_id"])
         self.google_client_secret = config.config_string(

--- a/src/beebop_deploy.py
+++ b/src/beebop_deploy.py
@@ -74,6 +74,7 @@ class BeebopConfig:
         self.client_url = config.config_string(dat, ["server", "client_url"])
         self.server_url = config.config_string(dat, ["server", "server_url"])
         self.redis_url = config.config_string(dat, ["server", "redis_url"])
+        self.server_node_options = config.config_string(dat, ["server", "node_options"])
         self.google_client_id = config.config_string(
             dat, ["server", "auth", "google", "client_id"])
         self.google_client_secret = config.config_string(
@@ -145,8 +146,9 @@ def beebop_constellation(cfg):
         configure=api_configure)
 
     # 3. server
+    server_env = {"NODE_OPTIONS": cfg.server_node_options}
     server = constellation.ConstellationContainer(
-        "server", cfg.server_ref, configure=server_configure(api))
+        "server", cfg.server_ref, environment=server_env, configure=server_configure(api), args=["--restart", "always"])
 
     # 4. worker
     worker_env = {"REDIS_HOST": redis.name}

--- a/src/beebop_deploy.py
+++ b/src/beebop_deploy.py
@@ -149,7 +149,12 @@ def beebop_constellation(cfg):
     # 3. server
     server_env = {"NODE_OPTIONS": cfg.server_node_options}
     server = constellation.ConstellationContainer(
-        "server", cfg.server_ref, environment=server_env, configure=server_configure(api), args=["--restart", "always"])
+        "server",
+        cfg.server_ref,
+        environment=server_env,
+        configure=server_configure(api),
+        args=["--restart", "always"],
+    )
 
     # 4. worker
     worker_env = {"REDIS_HOST": redis.name}


### PR DESCRIPTION
There was an issue where the JS heap memory ran out with a large project. I will add more robust fixes in the future when i have time (limiting number of samples, pagination)... A short term fix is to just up the default node heap memory (1.7GB --> 8GB)... this is pretty safe as both machines have 64GB of ram.


The following is deployed on production at beebop.dide.ic.ac.uk